### PR TITLE
fix currency error

### DIFF
--- a/include/kkiapay-give-class.php
+++ b/include/kkiapay-give-class.php
@@ -107,7 +107,17 @@ class Kkiapay_Give {
 
   function give_kkiapay_currency($currencies)
   {
-      $currencies['XOF'] = 'Fcfa';
+      // $currencies['XOF'] = 'Fcfa';
+      $currencies['XOF'] = [
+        'admin_label' => 'Fcfa',
+        "symbol" => 'XOF',
+        "setting" => [
+          'currency_position' => 'after',
+          "thousands_separator" =>" ",
+          "decimal_separator"=>",",
+          "number_decimals"=>0
+        ]
+      ];
       return $currencies;
   }
 


### PR DESCRIPTION
An object is expected by the function that returns the currency in give, but kkiapay-give was returning a string